### PR TITLE
Move away from `usize`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly

--- a/src/backend/ll1.rs
+++ b/src/backend/ll1.rs
@@ -132,7 +132,7 @@ pub fn calc_deduce_to_empty<A>(g: &Grammar<A>) -> Box<[bool]> {
         updated = false;
         for (nt, rules) in g.non_terminals().enumerate() {
             let new_val = rules.iter().any(|expr| expr.iter()
-                .all(|x| matches!(x, Symbol::NonTerminal(nt) if res[nt.get()])));
+                .all(|x| matches!(x, Symbol::NonTerminal(nt) if res[idx!(nt.get())])));
             updated |= res[nt] != new_val;
             res[nt] = new_val;
         }
@@ -166,7 +166,7 @@ pub fn append_first_of<'a, A, R, E, C, I>(expr: E, first: &'a [C], deduce_to_emp
                 return false;
             }
             Symbol::NonTerminal(nt) => {
-                let nt = nt.get();
+                let nt = idx!(nt.get());
                 for a in first[nt].borrow() {
                     *updated |= result.insert(a.clone().into());
                 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -362,6 +362,9 @@ pub mod dict {
 }
 
 impl<K> Dict<K> {
+    /// Get the size of this dict.
+    pub fn len(&self) -> usize { self.0.len() }
+
     fn locate<Q>(&self, key: Q) -> Result<usize, usize>
         where K: TupleCompare<Q> {
         self.0.binary_search_by(|a| a.tuple_compare(&key))

--- a/src/utils/interval.rs
+++ b/src/utils/interval.rs
@@ -62,19 +62,19 @@ use crate::utils::partition_refinement::{IndexManager, Part, Partitions};
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct Interval {
     /// Lower-bound (inclusive).
-    pub start: usize,
+    pub start: u32,
     /// Upper-bound (exclusive).
-    pub end: usize,
+    pub end: u32,
 }
 
 impl Interval {
     #[inline(always)]
     fn from_range<R>(range: R) -> Self
-        where R: RangeBounds<usize> {
+        where R: RangeBounds<u32> {
         let start = match range.start_bound() {
             Bound::Included(&start) => start,
             Bound::Excluded(&start) => start + 1,
-            Bound::Unbounded => usize::MIN,
+            Bound::Unbounded => u32::MIN,
         };
         let end = match range.end_bound() {
             Bound::Included(&end) => end + 1,
@@ -107,16 +107,16 @@ macro_rules! interval_from_range {
 }
 
 interval_from_range! {
-    Range<usize>,
-    RangeInclusive<usize>,
-    RangeTo<usize>,
-    RangeToInclusive<usize>,
+    Range<u32>,
+    RangeInclusive<u32>,
+    RangeTo<u32>,
+    RangeToInclusive<u32>,
     // RangeFrom & RangeFull are open on the right
 }
 
-impl RangeBounds<usize> for Interval {
-    fn start_bound(&self) -> Bound<&usize> { Bound::Included(&self.start) }
-    fn end_bound(&self) -> Bound<&usize> { Bound::Excluded(&self.end) }
+impl RangeBounds<u32> for Interval {
+    fn start_bound(&self) -> Bound<&u32> { Bound::Included(&self.start) }
+    fn end_bound(&self) -> Bound<&u32> { Bound::Excluded(&self.end) }
 }
 
 /// Interval set.
@@ -179,7 +179,7 @@ impl Intervals {
     /// # use rowantlr::utils::interval::Intervals;
     /// # use rowantlr::utils::partition_refinement::Partitions;
     /// let mut intervals: Intervals;
-    /// let mut partitions: Partitions<usize>;
+    /// let mut partitions: Partitions<u64>;
     /// # intervals = Intervals::new();
     /// # partitions = Partitions::new_trivial(7);
     /// # partitions.refine_with([1, 3, 5], &mut intervals);

--- a/src/utils/tuple.rs
+++ b/src/utils/tuple.rs
@@ -24,9 +24,9 @@
 ///
 /// ```
 /// # use rowantlr::utils::tuple::{TupleBorrow, TupleCompare};
-/// let data: (String, Vec<&'static str>, usize) =
+/// let data: (String, Vec<&'static str>, u64) =
 ///     ("answer".to_string(), vec!["life", "the universe", "everything"], 42);
-/// let borrowed: (&String, &Vec<&'static str>, &usize) = data.tuple_borrow();
+/// let borrowed: (&String, &Vec<&'static str>, &u64) = data.tuple_borrow();
 /// ```
 pub trait TupleBorrow<'a> {
     /// A tuple type shaped as `Self`, with each element replaced with its shared reference.
@@ -76,7 +76,7 @@ invoke_macro! {
 /// ```
 /// # use std::cmp::Ordering;
 /// # use rowantlr::utils::tuple::{TupleBorrow, TupleCompare};
-/// let data: (String, Vec<&'static str>, usize) =
+/// let data: (String, Vec<&'static str>, u64) =
 ///     ("answer".to_string(), vec!["life", "the universe", "everything"], 42);
 /// assert_eq!(data.tuple_compare(&("answer", )), Ordering::Equal);
 /// assert_eq!(data.tuple_compare(&("question", )), Ordering::Less);


### PR DESCRIPTION
Limit the use of `usize` for slice indices.

- Introduce `idx!` for conversion to `usize` as indices;
- Introduce `narrow!` for conversion from `usize` (usually a return value of method `len`);
- Replace `usize` with `u16`/`u32`/`u64`.