### PR TITLE
try adopting taiki-e/cargo-llvm-cov#141 for better reports

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,11 +67,10 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly
-        override: true
         profile: minimal
         components: llvm-tools-preview
     - name: Install llvm-cov
-      uses: taiki-e/install-action@cargo-llvm-cov
+      run: cargo install --git https://github.com/taiki-e/cargo-llvm-cov --branch disable-remap-path-prefix cargo-llvm-cov
     - name: Generate coverage report
       uses: actions-rs/cargo@v1
       with:

--- a/src/backend/dfa.rs
+++ b/src/backend/dfa.rs
@@ -57,7 +57,7 @@
 //!
 //! ```
 //! use rowantlr::ir::lexical::{Expr, PosInfo};
-//! use rowantlr::backend::dfa::{ResolveError, InvalidInput};
+//! use rowantlr::backend::dfa::ResolveError;
 //! // start with 'a', end with 'b'
 //! let e1 = Expr::concat([
 //!     Expr::singleton('a'),
@@ -121,7 +121,6 @@
 //! how the DFA can have equivalent states and be properly minimised:
 //! ```
 //! use rowantlr::ir::lexical::Expr;
-//! use rowantlr::backend::dfa::InvalidInput;
 //! let expr = Expr::union([
 //!     Expr::some(Expr::singleton('a')), // a+
 //!     Expr::some(Expr::from("aa")),     // (aa)+


### PR DESCRIPTION
Coverage dropped drastically (~90% to ~25%) after Nov 30, 2021, but the code was not modified at all. It is only possible due to the change in either `rustc` or `cargo-llvm-cov`. Let's first try to downgrade the easy one and see what's going on.